### PR TITLE
Continue on insert error

### DIFF
--- a/MailboxMiner2/pom.xml
+++ b/MailboxMiner2/pom.xml
@@ -9,6 +9,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
   <build>
     <resources>


### PR DESCRIPTION
Hi Nic,

Long time no see :-)

I've made some changes to the InsertModule in order to continue even when an error occurs for some email.

Instead of wrapping all emails in an mbox file into one large transaction, every emails becomes a separate transaction. Then, upon error, the email is skipped and insertion resumes with the next email. Some stats are shown about the number of unsuccessful inserts.

I tested it on >200k of emails, it seems to work well (with only few insertion errors).

Can you merge this pull request?

Thanks,

Bram

PS: The pom.xml change was necessary to compile the code.